### PR TITLE
[#163145909] users can now cancel pending delivery orders

### DIFF
--- a/UI/static/scripts/cancel.js
+++ b/UI/static/scripts/cancel.js
@@ -1,0 +1,27 @@
+'use strict';
+function cancelOrder() {
+    let parcel_id = window.location.search.split('parcel_id=')[1];
+    const url = 'https://sendit-api-v2-keith.herokuapp.com/api/v2/parcels/' + parcel_id + '/cancel';
+    fetch(url, {
+        method: 'PUT',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + window.localStorage.getItem('token')
+                }
+        })
+
+    .then(res => res.json())
+    .then(data => {
+        let success = data['Success'];
+        let error = data['Error'];
+
+        if (success) {
+            document.getElementById('success-feedback').innerHTML = success;
+        }
+
+        else {
+            document.getElementById('error-feedback').innerHTML = error;
+        }
+    });
+
+}


### PR DESCRIPTION
### What does this PR do?
users can cancel any pending orders they have created.

### Description of task to be accomplished
users should be able to cancel pending orders that they have created. Only logged in users who are not admins can cancel orders, and they can only cancel the orders that they have created.

### How can this be manually tested?
Log in a registered user from here https://mandelak.github.io/SendIT/UI/static/html/login.html then proceed to create a parcel using the user. If the user already has pending parcels on their profile page, you can cancel it by clicking on the name of the parcel, then you'll be redirected to a details page and the button to cancel the delivery is found at the bottom. Clicking this will cancel your order if it was still pending. 

### PT Stories
#163145909