### PR TITLE
[ #163146408] admins can now change current location of parcels

### DIFF
--- a/UI/static/scripts/location.js
+++ b/UI/static/scripts/location.js
@@ -1,0 +1,31 @@
+let p_id = window.location.search.split('parcel_id=')[1];
+// const url = 'https://sendit-api-v2-keith.herokuapp.com/api/v2/parcels/' + parcel_id + '/presentLocation';
+
+function changeLocation(parcel_id) {
+    let location = document.getElementById('current-loc').value;
+
+    fetch('https://sendit-api-v2-keith.herokuapp.com/api/v2/parcels/' + p_id + '/presentLocation', {
+        method: 'PUT',
+        headers: {
+        'Content-Type': 'application/json',
+        'Authorization': 'Bearer ' + window.localStorage.getItem('token')
+         },
+        body: JSON.stringify({
+        current_location: location
+    })
+    })
+
+    .then(res => res.json())
+    .then(data => {
+        let success = data['Success'];
+        let error = data['Error'];
+
+        if (success) {
+            document.getElementById('admin-success').innerHTML = success;
+        }
+
+        else {
+            document.getElementById('admin-error').innerHTML = error;
+        }
+    });
+    }


### PR DESCRIPTION
### What does this PR do?
the admin can now change the current location of all parcels in transit. They have to enter a valid location or else it returns an error.

### Description of task to be accomplished
Admins should be able to change the current location of parcels as they are being transported. This will keep the user always updated on where the parcel is and when it should be expected to reach its destination. 

### How can this be manually tested?
Because admins cannot create parcels, you should at least have made one order with a logged in user. You can always log in any user from here https://mandelak.github.io/SendIT/UI/static/html/login.html and then proceed to make an order. Also, because you cannot change the current location of pending parcels, you will need to change the status of your order and to do this you must log in as an admin and click on the individual parcel, then choose to change the status to 'transit'. After this, you can then proceed to change the current location by entering the valid location.

### PT Stories
#163146408
[#163145581]