### PR TITLE
[#163146335] admin can change the status of parcels

### DIFF
--- a/UI/static/scripts/status.js
+++ b/UI/static/scripts/status.js
@@ -1,0 +1,32 @@
+let parcel_id = window.location.search.split('parcel_id=')[1];
+const url = 'https://sendit-api-v2-keith.herokuapp.com/api/v2/parcels/' + parcel_id + '/status';
+
+
+function changeStatus() {
+    let status = document.getElementById('status').value;
+    fetch(url, {
+        method: 'PUT',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + window.localStorage.getItem('token')
+                },
+        body: JSON.stringify({
+            status: status
+        })
+        })
+
+    .then(res => res.json())
+    .then(data => {
+        let success = data['Success'];
+        let error = data['Error'];
+
+        if (success) {
+            document.getElementById('admin-success').innerHTML = success;
+        }
+
+        else {
+            document.getElementById('admin-error').innerHTML = error;
+        }
+    });
+
+}


### PR DESCRIPTION
### What does this PR do?
admins can now change the status of any parcels that haven't yet been delivered or cancelled. They access this feature by clicking on a specific parcel on their profile page and they will be redirected to a page where they can see the details about the parcel then proceed to change the status. 

### Description of task to be accomplished
Admins should be able to change the status of parcels so that users may keep track of them better. Admins can only change the status of parcels that are either pending or in transit.

### How can this be manually tested?
First of all, you will need to create an order, and you can only do this with regular users and not admins. Log a user in from here https://mandelak.github.io/SendIT/UI/static/html/login.html then proceed to make a new order with the user. Log out the user, then log in an admin and use the admin to change the status of the recently made order. Admins can only change the status to be either in transit or delivered.

### PT Stories
[#163146335]
[#163145581]